### PR TITLE
feat: Store ntnx API req ID as annotations on IPAddressClaim

### DIFF
--- a/internal/client/prism.go
+++ b/internal/client/prism.go
@@ -15,19 +15,26 @@ import (
 )
 
 const (
+	// RequestIDHeaderName is the name of the header that carries the request ID.
 	RequestIDHeaderName = "NTNX-Request-Id"
 )
 
 var (
-	ErrTaskFailed    = fmt.Errorf("task failed")
+	// ErrTaskFailed is returned when a task has failed.
+	ErrTaskFailed = fmt.Errorf("task failed")
+	// ErrTaskCancelled is returned when a task has been cancelled.
 	ErrTaskCancelled = fmt.Errorf("task cancelled")
-	ErrTaskOngoing   = fmt.Errorf("task ongoing")
+	// ErrTaskOngoing is returned when a task is still ongoing.
+	ErrTaskOngoing = fmt.Errorf("task ongoing")
 )
 
+// AsyncTaskOpts contains options for asynchronous tasks.
 type AsyncTaskOpts struct {
+	// RequestID is the ID of the request. This will be used to set the request ID header.
 	RequestID string
 }
 
+// ToRequestHeaders converts the options to a map of request headers.
 func (o AsyncTaskOpts) ToRequestHeaders() map[string]interface{} {
 	if o.RequestID == "" {
 		return nil
@@ -37,10 +44,12 @@ func (o AsyncTaskOpts) ToRequestHeaders() map[string]interface{} {
 	return headers
 }
 
+// PrismClient is the interface for interacting with Prism.
 type PrismClient interface {
 	GetTaskData(taskID string) ([]prismcommonapi.KVPair, error)
 }
 
+// Prism returns a PrismClient.
 func (c *client) Prism() PrismClient {
 	return &prismClient{v4Client: c.v4Client}
 }

--- a/internal/controllers/ipaddressclaim_test.go
+++ b/internal/controllers/ipaddressclaim_test.go
@@ -155,7 +155,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					mockNC.EXPECT().ReserveIP(
 						gomock.Any(),
 						pool.Spec.Subnet,
-						pcclient.ReserveIPOpts{Cluster: ""},
+						gomock.Any(),
 					).Return(
 						net.ParseIP("127.0.0.1"), nil,
 					).Times(1)
@@ -167,9 +167,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					mockNC := mockclient.NewMockNetworkingClient(mockController)
 					mockNC.EXPECT().UnreserveIP(
 						gomock.Any(),
-						net.ParseIP("127.0.0.1"),
 						pool.Spec.Subnet,
-						pcclient.UnreserveIPOpts{Cluster: ""},
+						gomock.Any(),
 					).Return(nil).Times(1)
 
 					return mockNC
@@ -237,7 +236,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 							mockNC.EXPECT().ReserveIP(
 								gomock.Any(),
 								pool.Spec.Subnet,
-								pcclient.ReserveIPOpts{Cluster: ""},
+								gomock.Any(),
 							).Return(
 								nil, errors.New("task failed"),
 							).Times(1)
@@ -252,7 +251,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 							mockNC.EXPECT().ReserveIP(
 								gomock.Any(),
 								pool.Spec.Subnet,
-								pcclient.ReserveIPOpts{Cluster: ""},
+								gomock.Any(),
 							).Return(
 								net.ParseIP("127.0.0.1"), nil,
 							).Times(1)
@@ -266,9 +265,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 							mockNC := mockclient.NewMockNetworkingClient(mockController)
 							mockNC.EXPECT().UnreserveIP(
 								gomock.Any(),
-								net.ParseIP("127.0.0.1"),
 								pool.Spec.Subnet,
-								pcclient.UnreserveIPOpts{Cluster: ""},
+								gomock.Any(),
 							).Return(
 								errors.New("task failed"),
 							).Times(1)
@@ -282,9 +280,8 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 							mockNC := mockclient.NewMockNetworkingClient(mockController)
 							mockNC.EXPECT().UnreserveIP(
 								gomock.Any(),
-								net.ParseIP("127.0.0.1"),
 								pool.Spec.Subnet,
-								pcclient.UnreserveIPOpts{Cluster: ""},
+								gomock.Any(),
 							).Return(nil).Times(1)
 							return mockNC
 						}).

--- a/internal/controllers/mockclient/mock_client.go
+++ b/internal/controllers/mockclient/mock_client.go
@@ -14,7 +14,6 @@
 package mockclient
 
 import (
-	context "context"
 	net "net"
 	reflect "reflect"
 
@@ -245,41 +244,41 @@ func (m *MockPrismClient) EXPECT() *MockPrismClientMockRecorder {
 	return m.recorder
 }
 
-// WaitForTaskCompletion mocks base method.
-func (m *MockPrismClient) WaitForTaskCompletion(arg0 context.Context, arg1 string, arg2 client.WaitForTaskCompletionOpts) ([]config.KVPair, error) {
+// GetTaskData mocks base method.
+func (m *MockPrismClient) GetTaskData(arg0 string) ([]config.KVPair, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForTaskCompletion", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetTaskData", arg0)
 	ret0, _ := ret[0].([]config.KVPair)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WaitForTaskCompletion indicates an expected call of WaitForTaskCompletion.
-func (mr *MockPrismClientMockRecorder) WaitForTaskCompletion(arg0, arg1, arg2 any) *MockPrismClientWaitForTaskCompletionCall {
+// GetTaskData indicates an expected call of GetTaskData.
+func (mr *MockPrismClientMockRecorder) GetTaskData(arg0 any) *MockPrismClientGetTaskDataCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForTaskCompletion", reflect.TypeOf((*MockPrismClient)(nil).WaitForTaskCompletion), arg0, arg1, arg2)
-	return &MockPrismClientWaitForTaskCompletionCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskData", reflect.TypeOf((*MockPrismClient)(nil).GetTaskData), arg0)
+	return &MockPrismClientGetTaskDataCall{Call: call}
 }
 
-// MockPrismClientWaitForTaskCompletionCall wrap *gomock.Call
-type MockPrismClientWaitForTaskCompletionCall struct {
+// MockPrismClientGetTaskDataCall wrap *gomock.Call
+type MockPrismClientGetTaskDataCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockPrismClientWaitForTaskCompletionCall) Return(arg0 []config.KVPair, arg1 error) *MockPrismClientWaitForTaskCompletionCall {
+func (c *MockPrismClientGetTaskDataCall) Return(arg0 []config.KVPair, arg1 error) *MockPrismClientGetTaskDataCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPrismClientWaitForTaskCompletionCall) Do(f func(context.Context, string, client.WaitForTaskCompletionOpts) ([]config.KVPair, error)) *MockPrismClientWaitForTaskCompletionCall {
+func (c *MockPrismClientGetTaskDataCall) Do(f func(string) ([]config.KVPair, error)) *MockPrismClientGetTaskDataCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPrismClientWaitForTaskCompletionCall) DoAndReturn(f func(context.Context, string, client.WaitForTaskCompletionOpts) ([]config.KVPair, error)) *MockPrismClientWaitForTaskCompletionCall {
+func (c *MockPrismClientGetTaskDataCall) DoAndReturn(f func(string) ([]config.KVPair, error)) *MockPrismClientGetTaskDataCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -308,7 +307,7 @@ func (m *MockNetworkingClient) EXPECT() *MockNetworkingClientMockRecorder {
 }
 
 // GetSubnet mocks base method.
-func (m *MockNetworkingClient) GetSubnet(arg0 string, arg1 client.ReserveIPOpts) (*client.Subnet, error) {
+func (m *MockNetworkingClient) GetSubnet(arg0 string, arg1 client.GetSubnetOpts) (*client.Subnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubnet", arg0, arg1)
 	ret0, _ := ret[0].(*client.Subnet)
@@ -335,19 +334,19 @@ func (c *MockNetworkingClientGetSubnetCall) Return(arg0 *client.Subnet, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNetworkingClientGetSubnetCall) Do(f func(string, client.ReserveIPOpts) (*client.Subnet, error)) *MockNetworkingClientGetSubnetCall {
+func (c *MockNetworkingClientGetSubnetCall) Do(f func(string, client.GetSubnetOpts) (*client.Subnet, error)) *MockNetworkingClientGetSubnetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkingClientGetSubnetCall) DoAndReturn(f func(string, client.ReserveIPOpts) (*client.Subnet, error)) *MockNetworkingClientGetSubnetCall {
+func (c *MockNetworkingClientGetSubnetCall) DoAndReturn(f func(string, client.GetSubnetOpts) (*client.Subnet, error)) *MockNetworkingClientGetSubnetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReserveIP mocks base method.
-func (m *MockNetworkingClient) ReserveIP(arg0 context.Context, arg1 string, arg2 client.ReserveIPOpts) (net.IP, error) {
+func (m *MockNetworkingClient) ReserveIP(arg0 client.IPReservationTypeFunc, arg1 string, arg2 client.ReserveIPOpts) (net.IP, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReserveIP", arg0, arg1, arg2)
 	ret0, _ := ret[0].(net.IP)
@@ -374,29 +373,29 @@ func (c *MockNetworkingClientReserveIPCall) Return(arg0 net.IP, arg1 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNetworkingClientReserveIPCall) Do(f func(context.Context, string, client.ReserveIPOpts) (net.IP, error)) *MockNetworkingClientReserveIPCall {
+func (c *MockNetworkingClientReserveIPCall) Do(f func(client.IPReservationTypeFunc, string, client.ReserveIPOpts) (net.IP, error)) *MockNetworkingClientReserveIPCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkingClientReserveIPCall) DoAndReturn(f func(context.Context, string, client.ReserveIPOpts) (net.IP, error)) *MockNetworkingClientReserveIPCall {
+func (c *MockNetworkingClientReserveIPCall) DoAndReturn(f func(client.IPReservationTypeFunc, string, client.ReserveIPOpts) (net.IP, error)) *MockNetworkingClientReserveIPCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UnreserveIP mocks base method.
-func (m *MockNetworkingClient) UnreserveIP(arg0 context.Context, arg1 net.IP, arg2 string, arg3 client.ReserveIPOpts) error {
+func (m *MockNetworkingClient) UnreserveIP(arg0 client.IPUnreservationTypeFunc, arg1 string, arg2 client.UnreserveIPOpts) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnreserveIP", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UnreserveIP", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnreserveIP indicates an expected call of UnreserveIP.
-func (mr *MockNetworkingClientMockRecorder) UnreserveIP(arg0, arg1, arg2, arg3 any) *MockNetworkingClientUnreserveIPCall {
+func (mr *MockNetworkingClientMockRecorder) UnreserveIP(arg0, arg1, arg2 any) *MockNetworkingClientUnreserveIPCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnreserveIP", reflect.TypeOf((*MockNetworkingClient)(nil).UnreserveIP), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnreserveIP", reflect.TypeOf((*MockNetworkingClient)(nil).UnreserveIP), arg0, arg1, arg2)
 	return &MockNetworkingClientUnreserveIPCall{Call: call}
 }
 
@@ -412,13 +411,13 @@ func (c *MockNetworkingClientUnreserveIPCall) Return(arg0 error) *MockNetworking
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNetworkingClientUnreserveIPCall) Do(f func(context.Context, net.IP, string, client.ReserveIPOpts) error) *MockNetworkingClientUnreserveIPCall {
+func (c *MockNetworkingClientUnreserveIPCall) Do(f func(client.IPUnreservationTypeFunc, string, client.UnreserveIPOpts) error) *MockNetworkingClientUnreserveIPCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkingClientUnreserveIPCall) DoAndReturn(f func(context.Context, net.IP, string, client.ReserveIPOpts) error) *MockNetworkingClientUnreserveIPCall {
+func (c *MockNetworkingClientUnreserveIPCall) DoAndReturn(f func(client.IPUnreservationTypeFunc, string, client.UnreserveIPOpts) error) *MockNetworkingClientUnreserveIPCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
This prevents blocking the control loop and allows for more
concurrent IP address handling.

This commit also switches to use a client context for unreserving
IP, instead of specifying a single IP to unreserve. The client
context is set to the IPAddressClaim UID when making the IP
reservation API call. Using the client context for unreservation
ensures that all IP addresses that are reserved with this client
context will be unreserved, which will also handle cases when there are
transient errors in reservation and multiple IPs are reserved without
storing as an IPAddress. While this scenario should be rare, it is
possible given the async API architecture so this adds a level of safety
to prevent IP address leakage.
