### PR TITLE
fix: corrected the path in the docs

### DIFF
--- a/docs/content/getting-started/deployment/via-clusterctl.md
+++ b/docs/content/getting-started/deployment/via-clusterctl.md
@@ -5,14 +5,14 @@ weight = 1
 +++
 
 Add the following to your `clusterctl.yaml` file, which is normally found at
-`${XDG_CONFIG_HOME}/cluster-api/clusterctl.yaml` (or `${HOME}/cluster-api/clusterctl.yaml`). See [clusterctl
+`${XDG_CONFIG_HOME}/.cluster-api/clusterctl.yaml` (or `${HOME}/cluster-api/.clusterctl.yaml`). See [clusterctl
 configuration file] for more details. If the `providers` section already exists, add the entry and omit the `providers`
 key from this block below:
 
 ```yaml
 providers:
   - name: "caipamx"
-    url: "https://github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix/releases/v{{< param "version" >}}/ipam-components.yaml"
+    url: "https://github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix/releases/download/v{{< param "version" >}}/ipam-components.yaml"
     type: "IPAMProvider"
 ```
 

--- a/docs/content/getting-started/deployment/via-clusterctl.md
+++ b/docs/content/getting-started/deployment/via-clusterctl.md
@@ -5,14 +5,14 @@ weight = 1
 +++
 
 Add the following to your `clusterctl.yaml` file, which is normally found at
-`${XDG_CONFIG_HOME}/.cluster-api/clusterctl.yaml` (or `${HOME}/cluster-api/.clusterctl.yaml`). See [clusterctl
+`${XDG_CONFIG_HOME}/.cluster-api/clusterctl.yaml` (or `${HOME}/.cluster-api/clusterctl.yaml`). See [clusterctl
 configuration file] for more details. If the `providers` section already exists, add the entry and omit the `providers`
 key from this block below:
 
 ```yaml
 providers:
   - name: "caipamx"
-    url: "https://github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix/releases/download/v{{< param "version" >}}/ipam-components.yaml"
+    url: "https://github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix/releases/latest/ipam-components.yaml"
     type: "IPAMProvider"
 ```
 

--- a/docs/content/getting-started/managing_ips/_index.md
+++ b/docs/content/getting-started/managing_ips/_index.md
@@ -37,7 +37,7 @@ EOF
 ## Create the IP pool
 
 ```shell
-$ export NUTANIX_ENDPOINT=https://<host>:9440
+$ export NUTANIX_ENDPOINT=<pc-ip or pc-fqdn>
 $ export NUTANIX_SUBNET=...
 
 $ cat <<EOF | kubectl apply --server-side -f -
@@ -49,7 +49,7 @@ spec:
   prismCentral:
     address: ${NUTANIX_ENDPOINT}
     port: 9440
-    credentialSecretRef:
+    credentialsSecretRef:
       name: pc-creds-for-ipam
   subnet: ${NUTANIX_SUBNET}
 EOF


### PR DESCRIPTION
**What problem does this PR solve?**:
was getting following error despite having correct dir per docs but docs was showing incorrect dir
<pre>
Error: failed to get provider components for the "caipamx:v0.2.0" provider: failed to get configuration for the IPAMProvider with name caipamx. Please check the provider name and/or add configuration for new providers using the .clusterctl config file
</pre>

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
Created mgmt cluster using nkp prompt cli

then tried to install ipam provider per docs but got following error
<pre>
clusterctl init --kubeconfig /Users/deepak.muley/ws/nkp/dm-mgmt.conf --infrastructure nutanix --ipam caipamx:v0.2.0 --wait-providers -v 10
Using configuration file="/Users/deepak.muley/.cluster-api/clusterctl.yaml"
Fetching providers
Potential override file searchFile="/Users/deepak.muley/Library/Application Support/cluster-api/overrides/infrastructure-nutanix/v1.5.3/infrastructure-components.yaml" provider="infrastructure-nutanix" version="v1.5.3"
Fetching file="infrastructure-components.yaml" provider="nutanix" type="InfrastructureProvider" version="v1.5.3"
Potential override file searchFile="/Users/deepak.muley/Library/Application Support/cluster-api/overrides/ipam-caipamx/v0.2.0/ipam-components.yaml" provider="ipam-caipamx" version="v0.2.0"
Fetching file="ipam-components.yaml" provider="caipamx" type="IPAMProvider" version="v0.2.0"
Potential override file searchFile="/Users/deepak.muley/Library/Application Support/cluster-api/overrides/cluster-api/v1.7.4-d2iq.5/metadata.yaml" provider="cluster-api" version="v1.7.4-d2iq.5"
Fetching file="metadata.yaml" provider="cluster-api" type="CoreProvider" version="v1.7.4-d2iq.5"
Error: failed to read "metadata.yaml" from the repository for provider "cluster-api": failed to download files from GitHub release v1.7.4-d2iq.5: failed to get file "metadata.yaml" from "v1.7.4-d2iq.5" release
sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository.(*metadataClient).Get
	sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository/metadata_client.go:81
sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster.(*providerInstaller).getProviderContract
	sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster/installer.go:308
sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster.(*providerInstaller).Validate
	sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster/installer.go:201
sigs.k8s.io/cluster-api/cmd/clusterctl/client.(*clusterctlClient).Init
	sigs.k8s.io/cluster-api/cmd/clusterctl/client/init.go:136
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.runInit
	sigs.k8s.io/cluster-api/cmd/clusterctl/cmd/init.go:148
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.init.func13
	sigs.k8s.io/cluster-api/cmd/clusterctl/cmd/init.go:88
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.8.1/command.go:985
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.8.1/command.go:1117
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.8.1/command.go:1041
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.Execute
	sigs.k8s.io/cluster-api/cmd/clusterctl/cmd/root.go:111
main.main
	sigs.k8s.io/cluster-api/cmd/clusterctl/main.go:27
runtime.main
	runtime/proc.go:272
runtime.goexit
	runtime/asm_arm64.s:1223
</pre>

and then had to add following in clusterctl.yaml because NKP cluster uses a different fork
<pre>
km get providers -A
NAMESPACE                           NAME                            AGE   TYPE                       PROVIDER         VERSION
caaph-system                        addon-helm                      22h   AddonProvider              helm             v0.2.4-d2iq.0
capa-system                         infrastructure-aws              22h   InfrastructureProvider     aws              v2.6.1
capg-system                         infrastructure-gcp              22h   InfrastructureProvider     gcp              v1.7.0
capi-kubeadm-bootstrap-system       bootstrap-kubeadm               22h   BootstrapProvider          kubeadm          v1.7.4-d2iq.5
capi-kubeadm-control-plane-system   control-plane-kubeadm           22h   ControlPlaneProvider       kubeadm          v1.7.4-d2iq.5
capi-system                         cluster-api                     22h   CoreProvider               cluster-api      v1.7.4-d2iq.5
cappp-system                        infrastructure-preprovisioned   22h   InfrastructureProvider     preprovisioned   v0.25.2
capv-system                         infrastructure-vsphere          22h   InfrastructureProvider     vsphere          v1.11.1
capvcd-system                       infrastructure-vcd              22h   InfrastructureProvider     vcd              v1.2.0-d2iq.1
capx-system                         infrastructure-nutanix          22h   InfrastructureProvider     nutanix          v1.5.3
capz-system                         infrastructure-azure            22h   InfrastructureProvider     azure            v1.17.0
caren-system                        runtime-extension-caren         22h   RuntimeExtensionProvider   caren            v0.14.7
kommander                           runtime-extension-kommander     22h   RuntimeExtensionProvider   kommander        v1.0.5-rc.4
</pre>

<pre>
providers:
  - name: "caipamx"
    url: "https://github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix/releases/latest/ipam-components.yaml"
    type: "IPAMProvider"
  - name: cluster-api
    type: CoreProvider
    url: "https://github.com/mesosphere/cluster-api/releases/latest/core-components.yaml"
</pre>

then it went ahead
<pre>
GOPROXY=off NUTANIX_ENDPOINT=... NUTANIX_USER=... NUTANIX_PASSWORD=... clusterctl init --kubeconfig /Users/deepak.muley/ws/nkp/dm-mgmt.conf --infrastructure nutanix --ipam caipamx:v0.2.0 --wait-providers
Using configuration file="/Users/deepak.muley/.cluster-api/clusterctl.yaml"
Fetching providers
Potential override file searchFile="/Users/deepak.muley/Library/Application Support/cluster-api/overrides/infrastructure-nutanix/v1.5.3/infrastructure-components.yaml" provider="infrastructure-nutanix" version="v1.5.3"
Fetching file="infrastructure-components.yaml" provider="nutanix" type="InfrastructureProvider" version="v1.5.3"
Potential override file searchFile="/Users/deepak.muley/Library/Application Support/cluster-api/overrides/ipam-caipamx/v0.2.0/ipam-components.yaml" provider="ipam-caipamx" version="v0.2.0"
Fetching file="ipam-components.yaml" provider="caipamx" type="IPAMProvider" version="v0.2.0"
Potential override file searchFile="/Users/deepak.muley/Library/Application Support/cluster-api/overrides/cluster-api/v1.7.4-d2iq.5/metadata.yaml" provider="cluster-api" version="v1.7.4-d2iq.5"
Fetching file="metadata.yaml" provider="cluster-api" type="CoreProvider" version="v1.7.4-d2iq.5"
Potential override file searchFile="/Users/deepak.muley/Library/Application Support/cluster-api/overrides/ipam-caipamx/v0.2.0/metadata.yaml" provider="ipam-caipamx" version="v0.2.0"
Fetching file="metadata.yaml" provider="caipamx" type="IPAMProvider" version="v0.2.0"
Creating Namespace="cert-manager-test"
Creating Issuer="test-selfsigned" Namespace="cert-manager-test"
Creating Certificate="selfsigned-cert" Namespace="cert-manager-test"
Deleting Namespace="cert-manager-test"
Deleting Issuer="test-selfsigned" Namespace="cert-manager-test"
Deleting Certificate="selfsigned-cert" Namespace="cert-manager-test"
Skipping installing cert-manager as it is already installed
Installing provider="ipam-caipamx" version="v0.2.0" targetNamespace="caipamx-system"
Creating objects provider="ipam-caipamx" version="v0.2.0" targetNamespace="caipamx-system"
Creating Namespace="caipamx-system"
Creating CustomResourceDefinition="nutanixippools.ipam.cluster.x-k8s.io"
Creating ServiceAccount="cluster-api-ipam-provider-nutanix" Namespace="caipamx-system"
Creating ClusterRole="cluster-api-ipam-provider-nutanix-manager-role"
Creating ClusterRoleBinding="cluster-api-ipam-provider-nutanix"
Creating Deployment="cluster-api-ipam-provider-nutanix" Namespace="caipamx-system"
Creating inventory entry provider="ipam-caipamx" version="v0.2.0" targetNamespace="caipamx-system"
Waiting for providers to be available...
Using configuration file="/Users/deepak.muley/.cluster-api/clusterctl.yaml"
</pre>

fixed following by correcting the docs as endponint should be just ip or fqdn without https and port
<pre>
km apply --server-side -f ./nutanixippool-sample.yaml
The NutanixIPPool "nutanixippool-sample" is invalid: 
* <nil>: Invalid value: "": "spec.prismCentral.address" must validate one and only one schema (oneOf). Found none valid
* spec.prismCentral.address: Invalid value: "https://pc.dev.nkp.sh:9440": spec.prismCentral.address in body must be of type ipv4: "https://pc.dev.nkp.sh:9440"
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
</pre>

get following error if we pass subnet name. per https://github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix/blob/main/api/v1alpha1/nutanixippool_types.go#L27 it is documented but need to check more
<pre>
apiVersion: ipam.cluster.x-k8s.io/v1alpha1
kind: NutanixIPPool
metadata:
  name: nutanixippool-sample
spec:
  prismCentral:
    address: pc-fqdn
    port: 9440
    credentialsSecretRef:
      name: pc-creds-for-ipam
  subnet: vlan173 <=====
</pre>
<pre>
km apply --server-side -f ./nutanixippool-sample.yaml
The NutanixIPPool "nutanixippool-sample" is invalid: spec: Invalid value: "object": cluster is required if subnet is not a valid uuid
</pre>

had to pass following uuid in subnet
<pre>
apiVersion: ipam.cluster.x-k8s.io/v1alpha1
kind: NutanixIPPool
metadata:
  name: nutanixippool-sample
spec:
  prismCentral:
    address: pc-fqdn
    port: 9440
    credentialsSecretRef:
      name: pc-creds-for-ipam
  subnet: b2e46975-2cde-4a49-9dda-815eb4fcd679
</pre>
<pre>
➜  ipam km apply --server-side -f ./nutanixippool-sample.yaml
nutanixippool.ipam.cluster.x-k8s.io/nutanixippool-sample serverside-applied
</pre>

applied following ip address claim
<pre>
apiVersion: ipam.cluster.x-k8s.io/v1beta1
kind: IPAddressClaim
metadata:
  name: my-ip
spec:
  poolRef:
    apiGroup: ipam.cluster.x-k8s.io
    kind: NutanixIPPool
    name: nutanixippool-sample
</pre>

<pre>
 km apply --server-side -f ./myip.yaml                
ipaddressclaim.ipam.cluster.x-k8s.io/my-ip serverside-applied
</pre>

but ip did not yet get created
<pre>
km get ipaddress my-ip
Error from server (NotFound): ipaddresses.ipam.cluster.x-k8s.io "my-ip" not found
</pre>
per ipam provider logs
<pre>
km -n caipamx-system logs -f cluster-api-ipam-provider-nutanix-7b55dd6db5-hdbld
</pre>

<pre>
2024-10-08 23:39:01.207 INFO - GET https://pc.dev.nkp.sh:9440/api/networking/v4.0.b1/config/subnets/b2e46975-2cde-4a49-9dda-815eb4fcd679
2024-10-08 23:39:01.403 INFO - HTTP/1.1 401 UNAUTHORIZED
2024-10-08 23:39:01.403 INFO - GET https://pc.dev.nkp.sh:9440/api/networking/v4.0.b1/config/subnets?%24filter=name+eq+%27b2e46975-2cde-4a49-9dda-815eb4fcd679%27
2024-10-08 23:39:01.719 INFO - HTTP/1.1 401 UNAUTHORIZED
E1008 23:39:01.728667       1 controller.go:324] "Reconciler error" err="failed to create or patch address: failed to reserve IP: failed to get subnet b2e46975-2cde-4a49-9dda-815eb4fcd679: failed to get subnet \"b2e46975-2cde-4a49-9dda-815eb4fcd679\": [failed to find subnet with extID \"b2e46975-2cde-4a49-9dda-815eb4fcd679\": {\"message\": \"User not found.\"}, failed to find subnet uuid for subnet \"b2e46975-2cde-4a49-9dda-815eb4fcd679\": {\"message\": \"User not found.\"}]" controller="ipaddressclaim" controllerGroup="ipam.cluster.x-k8s.io" controllerKind="IPAddressClaim" IPAddressClaim="default/my-ip" namespace="default" name="my-ip" reconcileID="21174b3f-26be-43da-aa13-953ebd747381"
</pre>

somehow ipaddressclaim status suppposed to tell the error same as log? we can add that if needed
<pre>
 km describe  ipaddressclaim  my-ip 
Name:         my-ip
Namespace:    default
Labels:       <none>
Annotations:  ipam.cluster.x-k8s.io/ntnx-reserve-ip-request-id: 01926e81-b60a-7d65-b810-0e1345c3fd66
API Version:  ipam.cluster.x-k8s.io/v1beta1
Kind:         IPAddressClaim
Metadata:
  Creation Timestamp:  2024-10-08T23:36:00Z
  Generation:          1
  Resource Version:    2720391
  UID:                 743c806e-14c9-4003-ac3b-49a3417b2548
Spec:
  Pool Ref:
    API Group:  ipam.cluster.x-k8s.io
    Kind:       NutanixIPPool
    Name:       nutanixippool-sample
Events:         <none>
</pre>

error from log says user not found. i am using tam created user, need to check if got expired
after recreating the user and passing cluster name with subnet name, am able to get ip
<pre>
km get ipaddress -A                                                            
NAMESPACE   NAME    ADDRESS       POOL NAME              POOL KIND       AGE
default     my-ip   10.x.x.x   nutanixippool-sample   NutanixIPPool   12s
</pre>

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
