### PR TITLE
refactor: Rename cluster flag to aos-cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ curl -fsSL https://github.com/nutanix-cloud-native/cluster-api-ipam-provider-nut
 #### Reserving an IP
 
 ```shell
-$ Reserve IP addresses in a subnet
+$ caipamx reserve --help
+Reserve IP addresses in a subnet
 
 Usage:
   caipamx reserve [flags]
@@ -68,7 +69,7 @@ Flags:
   -h, --help   help for reserve
 
 Global Flags:
-      --cluster string          Cluster to reserve IPs in, either UUID or name
+      --aos-cluster string      Nutanix AOS cluster to reserve IPs in, either UUID or name
       --password string         Password for Nutanix Prism Central (also configurable via NUTANIX_PASSWORD environment variable)
       --prism-endpoint string   Address of Nutanix Prism Central
       --subnet string           Subnet to reserve IPs in, either UUID or name
@@ -98,7 +99,8 @@ caipamx reserve <FLAGS> <IP_FROM>-<IP-TO>
 #### Unreserve an IP
 
 ```shell
-$ Unreserve IP addresses in a subnet
+$ caipamx unreserve --help
+Unreserve IP addresses in a subnet
 
 Usage:
   caipamx unreserve [flags]
@@ -107,7 +109,7 @@ Flags:
   -h, --help   help for unreserve
 
 Global Flags:
-      --cluster string          Cluster to reserve IPs in, either UUID or name
+      --aos-cluster string      Nutanix AOS cluster to reserve IPs in, either UUID or name
       --password string         Password for Nutanix Prism Central (also configurable via NUTANIX_PASSWORD environment variable)
       --prism-endpoint string   Address of Nutanix Prism Central
       --subnet string           Subnet to reserve IPs in, either UUID or name

--- a/cmd/caipamx/main.go
+++ b/cmd/caipamx/main.go
@@ -67,10 +67,19 @@ func main() {
 	must(rootCmd.MarkPersistentFlagRequired("subnet"))
 
 	persistentFlags.String(
+		"aos-cluster",
+		"",
+		"Nutanix AOS cluster to reserve IPs in, either UUID or name",
+	)
+
+	// Deprecated flag
+	persistentFlags.String(
 		"cluster",
 		"",
-		"Cluster to reserve IPs in, either UUID or name",
+		"Nutanix AOS cluster to reserve IPs in, either UUID or name",
 	)
+	must(persistentFlags.MarkDeprecated("cluster", "use --aos-cluster instead"))
+	rootCmd.MarkFlagsMutuallyExclusive("cluster", "aos-cluster")
 
 	// Bind the flags to viper
 	must(viper.BindPFlags(persistentFlags))

--- a/cmd/caipamx/reserve.go
+++ b/cmd/caipamx/reserve.go
@@ -65,7 +65,10 @@ func reserveCmd() *cobra.Command {
 			}
 
 			subnet := viper.GetString("subnet")
-			cluster := viper.GetString("cluster")
+			aosCluster := viper.GetString("aos-cluster")
+			if aosCluster == "" {
+				aosCluster = viper.GetString("cluster")
+			}
 
 			var ips []netip.Addr
 
@@ -83,7 +86,7 @@ func reserveCmd() *cobra.Command {
 							AsyncTaskOpts: client.AsyncTaskOpts{
 								RequestID: requestID.String(),
 							},
-							Cluster: cluster,
+							Cluster: aosCluster,
 						},
 					)
 					if err != nil {

--- a/cmd/caipamx/unreserve.go
+++ b/cmd/caipamx/unreserve.go
@@ -57,6 +57,11 @@ func unreserveCmd() *cobra.Command {
 				return fmt.Errorf("failed to generate request ID: %w", err)
 			}
 
+			aosCluster := viper.GetString("aos-cluster")
+			if aosCluster == "" {
+				aosCluster = viper.GetString("cluster")
+			}
+
 			err = wait.PollUntilContextTimeout(
 				context.Background(),
 				time.Second,
@@ -70,7 +75,7 @@ func unreserveCmd() *cobra.Command {
 							AsyncTaskOpts: client.AsyncTaskOpts{
 								RequestID: requestID.String(),
 							},
-							Cluster: viper.GetString("cluster"),
+							Cluster: aosCluster,
 						},
 					)
 					if err != nil {


### PR DESCRIPTION
Retained but marked as deprecated for backwards compatibility.

Fixes #47.
