### PR TITLE
fix: getByExt incorrectly expecting pointers

### DIFF
--- a/internal/client/cluster.go
+++ b/internal/client/cluster.go
@@ -107,7 +107,7 @@ func (n *clusterClient) getClusterByExtID(clusterExtID uuid.UUID) (*Cluster, err
 	}
 
 	switch apiCluster := cluster.(type) {
-	case *clustersapi.Cluster:
+	case clustersapi.Cluster:
 		if apiCluster.ExtId == nil {
 			return nil, fmt.Errorf("no extID found for cluster %q", clusterExtID)
 		}

--- a/internal/client/networking.go
+++ b/internal/client/networking.go
@@ -530,7 +530,7 @@ func (n *networkingClient) getSubnetByExtID(subnetExtID uuid.UUID) (*Subnet, err
 	}
 
 	switch apiSubnet := subnet.(type) {
-	case *networkingapi.Subnet:
+	case networkingapi.Subnet:
 		if apiSubnet.ExtId == nil {
 			return nil, fmt.Errorf("no extID found for subnet %q", subnetExtID)
 		}


### PR DESCRIPTION
**What problem does this PR solve?**:
While testing https://github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix/pull/42 I ran into an `unknown response:` error when using a Subnet UUID.

The types are already dereferenced in the SDK https://github.com/nutanix/ntnx-api-golang-clients/blob/ebacb54f220ab8328903cd80064c826466e800da/networking-go-client/models/networking/v4/config/config_model.go#L14758-L14766

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
