### PR TITLE
fix: run snapshot manifest hooks in one shell

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,8 +40,9 @@ archives:
 
 before:
   hooks:
-    - kustomize build ./config/default >ipam-components.yaml
-    - sed -i -e 's/v0.0.0-dev/v{{ trimprefix .Version "v" }}/g' ipam-components.yaml
+    - |
+      sh -ec 'kustomize build ./config/default >ipam-components.yaml
+        sed -i -e "s/v0.0.0-dev/v{{ trimprefix .Version "v" }}/g" ipam-components.yaml'
     - |
       sh -ec 'gojq --yaml-input --yaml-output \
         ".releaseSeries |= (. + [{contract: \"v1beta1\", major: {{ .Major }}, minor: {{ .Minor }}}] | unique)" \


### PR DESCRIPTION
## Summary
- Run the `kustomize` manifest generation and version substitution in one GoReleaser hook.
- Fix `make build-snapshot` failing when the second hook cannot find `ipam-components.yaml`.

## Test plan
- `devbox run -- make build-snapshot`


Made with [Cursor](https://cursor.com)