### PR TITLE
ci: migrate to Black Duck security scan action

### DIFF
--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -51,22 +51,22 @@ jobs:
 
       - name: Black Duck Full Scan
         if: ${{ github.event_name != 'pull_request' }}
-        uses: synopsys-sig/synopsys-action@v1.13.0
+        uses: blackduck-inc/black-duck-security-scan@v2.10.0
         with:
-          blackduck_url: ${{ secrets.BLACKDUCK_URL }}
-          blackduck_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
+          blackducksca_url: ${{ secrets.BLACKDUCK_URL }}
+          blackducksca_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          blackduck_scan_full: true
-          blackduck_scan_failure_severities: 'BLOCKER,CRITICAL'
+          blackducksca_scan_full: true
+          blackducksca_scan_failure_severities: 'BLOCKER,CRITICAL'
 
       - name: Black Duck PR Scan
         if: ${{ github.event_name == 'pull_request' }}
-        uses: synopsys-sig/synopsys-action@v1.13.0
+        uses: blackduck-inc/black-duck-security-scan@v2.10.0
         env:
           DETECT_PROJECT_VERSION_NAME: ${{ github.base_ref }}
         with:
-          blackduck_url: ${{ secrets.BLACKDUCK_URL }}
-          blackduck_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
+          blackducksca_url: ${{ secrets.BLACKDUCK_URL }}
+          blackducksca_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          blackduck_scan_full: false
-          blackduck_prComment_enabled: true
+          blackducksca_scan_full: false
+          blackducksca_prComment_enabled: true


### PR DESCRIPTION
## Summary
- Replace deprecated `synopsys-sig/synopsys-action` with `blackduck-inc/black-duck-security-scan@v2.10.0`.
- Rename Black Duck inputs to the supported `blackducksca_*` names.
- Avoid Bridge download failures from legacy `sig-repo.synopsys.com` infrastructure.

## Test plan
- `devbox run -- actionlint .github/workflows/synopsys.yaml`