### PR TITLE
ci: use go1.25 and go1.26.3 toolchain

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -74,13 +74,24 @@ jobs:
       - name: Export golang and golangci-lint versions
         id: versions
         run: |
-          echo "golangci-lint=$(devbox run -- golangci-lint version --format short)" >>"${GITHUB_OUTPUT}"
-          echo "golang=$(devbox run -- go version | grep -o "[[:digit:]]\+.[[:digit:]]\+\(.[[:digit:]]\+\)\?")" >>"${GITHUB_OUTPUT}"
+          golangci_lint_version="$(
+            devbox run -- golangci-lint version --short |
+              sed -n 's/^\([[:digit:]][[:digit:].]*\)$/\1/p' |
+              head -n 1
+          )"
+          go_version="$(
+            devbox run -- go env GOVERSION |
+              sed -n 's/^go//p' |
+              head -n 1
+          )"
+
+          echo "golangci-lint=${golangci_lint_version}" >>"${GITHUB_OUTPUT}"
+          echo "golang=${go_version}" >>"${GITHUB_OUTPUT}"
 
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
-          fail_on_error: true
+          fail_level: error
           reporter: github-pr-review
           golangci_lint_version: v${{ steps.versions.outputs.golangci-lint }}
           go_version: v${{ steps.versions.outputs.golang }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,7 +109,7 @@ jobs:
       - name: actionlint
         uses: reviewdog/action-actionlint@v1
         with:
-          fail_on_error: true
+          fail_level: error
           reporter: github-pr-review
 
   pre-commit:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,12 @@
 # Copyright 2021-2023 Nutanix. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+version: "2"
 run:
-  timeout: 10m
   build-tags:
     - e2e
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - containedctx
     - contextcheck
@@ -16,25 +15,20 @@ linters:
     - errchkjson
     - errname
     - gochecknoinits
-    - gci
     - goconst
     - gocritic
     - gocyclo
     - godot
-    - gofumpt
     - gomoddirectives
     - gosec
-    - gosimple
     - govet
-    - ineffassign
     - importas
+    - ineffassign
     - lll
     - misspell
     - nolintlint
     - prealloc
     - staticcheck
-    - stylecheck
-    - tenv
     - testifylint
     - thelper
     - tparallel
@@ -42,61 +36,90 @@ linters:
     - unparam
     - unused
     - whitespace
-
-linters-settings:
-  depguard:
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          deny:
+            - pkg: k8s.io/kubernetes
+              desc: do not use k8s.io/kubernetes directly
+    errcheck:
+      exclude-functions:
+        - encoding/json.Marshal
+        - encoding/json.MarshalIndent
+    errchkjson:
+      check-error-free-encoding: true
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gomoddirectives:
+      replace-allow-list:
+        - github.com/nutanix-cloud-native/prism-go-client
+    importas:
+      alias:
+        - pkg: sigs.k8s.io/cluster-api/api/v1beta1
+          alias: clusterv1
+      no-unaliased: false
+    lll:
+      line-length: 120
+    staticcheck:
+      checks:
+        - all
+        - -QF1008
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega
+    testifylint:
+      enable-all: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      main:
-        list-mode: lax # Allow everything unless explicitly denied below.
-        deny:
-          - pkg: k8s.io/kubernetes
-            desc: "do not use k8s.io/kubernetes directly"
-  errcheck:
-    exclude-functions:
-      - encoding/json.Marshal
-      - encoding/json.MarshalIndent
-  errchkjson:
-    check-error-free-encoding: true
-  gci:
-    sections:
-      - Standard
-      - Default
-      - Prefix(github.com/nutanix-cloud-native)
-      - localmodule
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  gofumpt:
-    extra-rules: true
-  gomoddirectives:
-    replace-allow-list:
-      - github.com/nutanix-cloud-native/prism-go-client
-  importas:
-    no-unaliased: false
-    alias:
-      - pkg: "sigs.k8s.io/cluster-api/api/v1beta1"
-        alias: clusterv1
-  lll:
-    line-length: 120
-  stylecheck:
-    # https://staticcheck.io/docs/configuration/options/#dot_import_whitelist
-    dot-import-whitelist:
-      - github.com/onsi/ginkgo/v2
-      - github.com/onsi/gomega
-  testifylint:
-    enable-all: true
-
-issues:
-  exclude-rules:
-    # ignore errcheck for flags.Parse (it is expected that we flag.ExitOnError)
-    # ignore response.WriteError as it always returns the err it was passed
-    - source: "flags.Parse|response.WriteError"
-      linters:
-        - errcheck
-    - source: "//( \\+kubebuilder:|go:generate)"
-      linters:
-        - lll
+      - linters:
+          - goconst
+        path: _test\.go
+      - linters:
+          - errcheck
+        source: flags.Parse|response.WriteError
+      - linters:
+          - gosec
+        path: internal/test/envtest/environment\.go
+        text: G703
+      - linters:
+          - lll
+        source: func .*getSubnetByName
+      - linters:
+          - lll
+        source: //( \+kubebuilder:|go:generate)
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - Standard
+        - Default
+        - Prefix(github.com/nutanix-cloud-native)
+        - localmodule
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/devbox.lock
+++ b/devbox.lock
@@ -729,50 +729,50 @@
       }
     },
     "golangci-lint@latest": {
-      "last_modified": "2025-02-16T21:44:05Z",
-      "resolved": "github:NixOS/nixpkgs/f0204ef4baa3b6317dee1c84ddeffbd293638836#golangci-lint",
+      "last_modified": "2026-05-21T08:15:18Z",
+      "resolved": "github:NixOS/nixpkgs/4a29d733e8a7d5b824c3d8c958a946a9867b3eb2#golangci-lint",
       "source": "devbox-search",
-      "version": "1.64.5",
+      "version": "2.12.2",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jh2f466rbi0pgk6f3w8jdzy4qyccybz3-golangci-lint-1.64.5",
+              "path": "/nix/store/paiggn2x6idsnhzn6ss6sdn87lvqadlf-golangci-lint-2.12.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/jh2f466rbi0pgk6f3w8jdzy4qyccybz3-golangci-lint-1.64.5"
+          "store_path": "/nix/store/paiggn2x6idsnhzn6ss6sdn87lvqadlf-golangci-lint-2.12.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/63mvzwlqana7bfcy8jzmn3fvkn46k0p6-golangci-lint-1.64.5",
+              "path": "/nix/store/mxcfgfnl675mlqnm7v3zliq0y1wisw7i-golangci-lint-2.12.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/63mvzwlqana7bfcy8jzmn3fvkn46k0p6-golangci-lint-1.64.5"
+          "store_path": "/nix/store/mxcfgfnl675mlqnm7v3zliq0y1wisw7i-golangci-lint-2.12.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/d662i9k8p2alplmxc3bqypc646x7wy1b-golangci-lint-1.64.5",
+              "path": "/nix/store/80gb4fz1fs06h9y8c7xb80yfz0zd3qaa-golangci-lint-2.12.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/d662i9k8p2alplmxc3bqypc646x7wy1b-golangci-lint-1.64.5"
+          "store_path": "/nix/store/80gb4fz1fs06h9y8c7xb80yfz0zd3qaa-golangci-lint-2.12.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/25732rsdh49iwjrik69sb9cfhiza00b5-golangci-lint-1.64.5",
+              "path": "/nix/store/x3ism4ihdsansi2y1ldhs78244pxv22w-golangci-lint-2.12.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/25732rsdh49iwjrik69sb9cfhiza00b5-golangci-lint-1.64.5"
+          "store_path": "/nix/store/x3ism4ihdsansi2y1ldhs78244pxv22w-golangci-lint-2.12.2"
         }
       }
     },

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix
 
-go 1.24.0
+go 1.25
 
 toolchain go1.26.3
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-ipam-provider-nutanix
 
 go 1.24.0
 
-toolchain go1.24.1
+toolchain go1.26.3
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary
- Update the root `go.mod` toolchain directive from `go1.24.1` to `go1.26.3`.
- Update the root `go.mod` version to `go1.25`
- Update golangci-lint config to v2

## Test plan
- `go list ./internal/client`
- `go test ./internal/client ./cmd/controller ./cmd/caipamx`


Made with [Cursor](https://cursor.com)